### PR TITLE
Fixed "Open Windows Terminal Here" on a drive root

### DIFF
--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -32,6 +32,8 @@ HKLM,%UDHERE%,DisplayName,,"%WindowsTerminalHereName%"
 HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultUninstall 132 %17%\WindowsTerminalHere.inf"
 HKCR,Directory\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Directory\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1"""
+HKCR,Directory\Background\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
+HKCR,Directory\Background\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%V"""
 HKCR,Drive\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1\"""
 

--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -33,7 +33,7 @@ HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallA
 HKCR,Directory\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Directory\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1"""
 HKCR,Drive\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
-HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1"""
+HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1\"""
 
 [Strings]
 WindowsTerminalHereName="Windows Terminal Here PowerToy"

--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -37,5 +37,5 @@ HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Micr
 
 [Strings]
 WindowsTerminalHereName="Windows Terminal Here PowerToy"
-WindowsTerminalHereAccel="Windows &Terminal Here"
+WindowsTerminalHereAccel="Open Windows &Terminal Here"
 UDHERE="Software\Microsoft\Windows\CurrentVersion\Uninstall\WindowsTerminalHere"


### PR DESCRIPTION
- Fixed #4 
- Change the menu label from `Windows Terminal Here` to `Open Windows Terminal Here`