### PR TITLE
Fixed "Open Windows Terminal Here" on drive root

### DIFF
--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -39,5 +39,5 @@ HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Micr
 
 [Strings]
 WindowsTerminalHereName="Windows Terminal Here PowerToy"
-WindowsTerminalHereAccel="Windows &Terminal Here"
+WindowsTerminalHereAccel="Open Windows &Terminal Here"
 UDHERE="Software\Microsoft\Windows\CurrentVersion\Uninstall\WindowsTerminalHere"

--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -35,7 +35,7 @@ HKCR,Directory\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\
 HKCR,Directory\Background\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Directory\Background\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%V"""
 HKCR,Drive\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
-HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1"""
+HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1\"""
 
 [Strings]
 WindowsTerminalHereName="Windows Terminal Here PowerToy"


### PR DESCRIPTION
- Fixed #4 
- Change the label "Windows Terminal Here" to "Open Windows Terminal Here"