### PR TITLE
Remove dead registry entries

### DIFF
--- a/WindowsTerminalHere.inf
+++ b/WindowsTerminalHere.inf
@@ -28,14 +28,18 @@ WindowsTerminalHere.Files.Inf = 17
 WindowsTerminalHere.INF
 
 [WindowsTerminalHere.Reg]
+HKLM,%UDHERE%
 HKLM,%UDHERE%,DisplayName,,"%WindowsTerminalHereName%"
 HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultUninstall 132 %17%\WindowsTerminalHere.inf"
+HKCR,Directory\Shell\WindowsTerminalHere
 HKCR,Directory\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Directory\Shell\WindowsTerminalHere,Icon,,"%WindowsTerminalHereIcon%"
 HKCR,Directory\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1"""
+HKCR,Directory\Background\Shell\WindowsTerminalHere
 HKCR,Directory\Background\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Directory\Background\Shell\WindowsTerminalHere,Icon,,"%WindowsTerminalHereIcon%"
 HKCR,Directory\Background\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%V"""
+HKCR,Drive\Shell\WindowsTerminalHere
 HKCR,Drive\Shell\WindowsTerminalHere,,,"%WindowsTerminalHereAccel%"
 HKCR,Drive\Shell\WindowsTerminalHere,Icon,,"%WindowsTerminalHereIcon%"
 HKCR,Drive\Shell\WindowsTerminalHere\command,,0x00020000,""%%LOCALAPPDATA%%\Microsoft\WindowsApps\wt.exe -d " ""%1\"""


### PR DESCRIPTION
## Bug description
After uninstallation, context menu entries aren't removed completely and subkeys named `WindowsTerminalHere` stay unaffected.

## Root cause
When `[DefaultUnInstall]` kicks off, empty subkeys are not deleted because `DelReg` doesn't cleanup subkeys (root of subtree) that are created along with their values.

## Solution description
The change adds subkeys (root of subtree) to `[WindowsTerminalHere.Reg]` section independently so that `DelReg` removes them during uninstallation.